### PR TITLE
feat(issue-templates): add optional Milestone + Parent issue + Plan fields

### DIFF
--- a/.github/ISSUE_TEMPLATE/01-bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/01-bug-report.yml
@@ -68,6 +68,27 @@ body:
       description: Excerpts only — no scratch-dir paths or absolute home-dir paths the reviewer cannot open.
       render: text
 
+  - type: input
+    id: parent
+    attributes:
+      label: Parent issue
+      description: |
+        Issue number or full URL of the tracking / parent issue this bug
+        belongs to, if any. Same-repo form: `#1234`. Cross-repo form:
+        `https://github.com/<owner>/<repo>/issues/1234`. The
+        /workflow:create-issue skill registers the sub-issue link
+        automatically when filed via the CLI.
+      placeholder: "#1234 or https://github.com/<owner>/<repo>/issues/1234"
+
+  - type: input
+    id: milestone
+    attributes:
+      label: Milestone
+      description: |
+        Existing milestone name to attach this bug to. Leave blank for
+        one-off bugs that don't belong to a milestone.
+      placeholder: "e.g. sp1: v5.0.0"
+
   - type: textarea
     id: knowledge
     attributes:

--- a/.github/ISSUE_TEMPLATE/02-feature-request.yml
+++ b/.github/ISSUE_TEMPLATE/02-feature-request.yml
@@ -44,13 +44,28 @@ body:
       required: true
 
   - type: textarea
+    id: plan
+    attributes:
+      label: Plan
+      description: |
+        Checkbox list of work steps. GitHub shows N/M completed in the
+        issue header. /workflow:handle-issue ticks these as work
+        progresses; /spec-driven-development output can be inlined
+        verbatim here for full context. Leave blank if no plan exists
+        yet — a prefilled `value:` would make untouched submissions
+        show a misleading "0/2 complete".
+      placeholder: |
+        - [ ] step 1
+        - [ ] step 2
+
+  - type: textarea
     id: acceptance
     attributes:
       label: Acceptance criteria
       description: |
-        Checkbox list. GitHub shows N/M completed in the issue header,
-        so leave blank if you have no criteria — a prefilled `value:`
-        would make every untouched submission show "0/2 complete".
+        Checkbox list of outcome conditions (distinct from Plan above —
+        Plan is the steps to get there, Acceptance is how we know we're
+        done). GitHub shows N/M completed in the issue header.
       placeholder: |
         - [ ] criterion 1
         - [ ] criterion 2
@@ -60,6 +75,28 @@ body:
     attributes:
       label: References
       description: Links to prior PRs, papers, design docs, related issues.
+
+  - type: input
+    id: parent
+    attributes:
+      label: Parent issue
+      description: |
+        Issue number or full URL of the tracking / parent issue this
+        work is a sub-task of. Same-repo form: `#1234`. Cross-repo form:
+        `https://github.com/<owner>/<repo>/issues/1234`. The
+        /workflow:create-issue skill registers the sub-issue link
+        automatically when filed via the CLI.
+      placeholder: "#1234 or https://github.com/<owner>/<repo>/issues/1234"
+
+  - type: input
+    id: milestone
+    attributes:
+      label: Milestone
+      description: |
+        Existing milestone name to attach this issue to. The
+        /workflow:create-issue skill checks the milestone exists before
+        applying it.
+      placeholder: "e.g. zisk: subphase 1 harness"
 
   - type: textarea
     id: knowledge


### PR DESCRIPTION
## Description

Universal templates were flat — no way to group related work for things like a multi-issue rollout (e.g. "zisk: subphase 1 harness") or to track a spec-driven plan's progress inside the issue body. Adds three optional fields without breaking existing one-off filings:

- **Milestone** (input on bug + feature): existing GitHub milestones give soft grouping + progress bar at the milestone page and a native column in Projects v2. The `/workflow:create-issue` skill already had milestone-resolution code; this just surfaces it from the template.

- **Parent issue** (input on bug + feature): GitHub's [sub-issue API](https://docs.github.com/en/rest/issues/sub-issues) (GA 2024) links a child to its parent. The parent renders an `N/M` progress bar over its children and the relationship is visible in the issue UI. `/workflow:create-issue` registers the link via `POST /repos/{owner}/{repo}/issues/{N}/sub_issues` automatically when the field is set (see companion `fractalyze/claude-plugins` PR).

- **Plan** (textarea on feature only): checkbox list of work steps, distinct from Acceptance criteria — Plan is the steps to get there, Acceptance is how we know we're done. `/workflow:handle-issue` ticks these as work progresses; `/spec-driven-development` output can be inlined verbatim here for full context.

All three fields are **OPTIONAL** — one-off bugs and quick features file the same way they did before. Docs template stays unchanged (docs issues rarely need grouping or plans).

## Related

- Companion PR on `fractalyze/claude-plugins` adds the skill-side logic that consumes these new fields (sub-issue link via API, checkbox auto-tick in `/handle-issue` wrap step).

## Checklist

- [x] Branch name follows Branch Guideline
- [x] Commit messages follow Commit Message Guideline
- [x] Checked Pull Request Guideline
