### PR TITLE
feat(issue-templates): add optional Area dropdown to universal templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/01-bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/01-bug-report.yml
@@ -68,6 +68,27 @@ body:
       description: Excerpts only — no scratch-dir paths or absolute home-dir paths the reviewer cannot open.
       render: text
 
+  - type: dropdown
+    id: area
+    attributes:
+      label: Area
+      description: |
+        Which part of the system this belongs to. The
+        /workflow:create-issue skill maps the pick to an `area:*` label;
+        a repo may define finer areas (e.g. riscv-witness `area:sp1`) in
+        its own templates.
+        - `zkvm` — vendor / version / subphase (SP1, OpenVM, ZisK)
+        - `compiler` — zk compiler stack (zk_dtypes, prime_ir, stablehlo, zkx, jax fork)
+        - `downstream` — proof generator / partner consumer
+        - `tooling` — build / CI / dev infra
+      options:
+        - zkvm
+        - compiler
+        - downstream
+        - tooling
+    validations:
+      required: false
+
   - type: input
     id: parent
     attributes:

--- a/.github/ISSUE_TEMPLATE/02-feature-request.yml
+++ b/.github/ISSUE_TEMPLATE/02-feature-request.yml
@@ -76,6 +76,27 @@ body:
       label: References
       description: Links to prior PRs, papers, design docs, related issues.
 
+  - type: dropdown
+    id: area
+    attributes:
+      label: Area
+      description: |
+        Which part of the system this belongs to. The
+        /workflow:create-issue skill maps the pick to an `area:*` label;
+        a repo may define finer areas (e.g. riscv-witness `area:sp1`) in
+        its own templates.
+        - `zkvm` — vendor / version / subphase (SP1, OpenVM, ZisK)
+        - `compiler` — zk compiler stack (zk_dtypes, prime_ir, stablehlo, zkx, jax fork)
+        - `downstream` — proof generator / partner consumer
+        - `tooling` — build / CI / dev infra
+      options:
+        - zkvm
+        - compiler
+        - downstream
+        - tooling
+    validations:
+      required: false
+
   - type: input
     id: parent
     attributes:

--- a/.github/ISSUE_TEMPLATE/03-documentation.yml
+++ b/.github/ISSUE_TEMPLATE/03-documentation.yml
@@ -24,6 +24,25 @@ body:
     attributes:
       label: Suggested fix
 
+  - type: dropdown
+    id: area
+    attributes:
+      label: Area
+      description: |
+        Which part of the system these docs cover. The
+        /workflow:create-issue skill maps the pick to an `area:*` label.
+        - `zkvm` — vendor / version / subphase (SP1, OpenVM, ZisK)
+        - `compiler` — zk compiler stack (zk_dtypes, prime_ir, stablehlo, zkx, jax fork)
+        - `downstream` — proof generator / partner consumer
+        - `tooling` — build / CI / dev infra
+      options:
+        - zkvm
+        - compiler
+        - downstream
+        - tooling
+    validations:
+      required: false
+
   - type: textarea
     id: knowledge
     attributes:


### PR DESCRIPTION
## Description

Captures which part of the system an issue belongs to at filing time, so the board is filterable by area regardless of whether the issue was filed via the web UI or `/workflow:create-issue`. Options are the org-wide orthogonal base (`zkvm` / `compiler` / `downstream` / `tooling`); the skill maps the pick to an `area:*` label, and a repo may define finer areas (e.g. `area:sp1`) in its own templates. `area:spec-driven` stays a skill-applied process marker, not a dropdown choice. Optional — left blank when unknown.

Pairs with the claude-plugins skill changes that consume the field (type+area recommendation). Per-repo `area` dropdowns are a follow-up.

## Related Issues/PRs

Part of fractalyze/claude-plugins#39

## Checklist

- [x] Branch name follows Branch Guideline
- [x] Commit messages follow Commit Message Guideline
- [x] Checked Pull Request Guideline