### PR TITLE
fix(issue-templates): default the Area dropdown to a blank "none / unsure"

### DIFF
--- a/.github/ISSUE_TEMPLATE/01-bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/01-bug-report.yml
@@ -82,6 +82,7 @@ body:
         - `downstream` — proof generator / partner consumer
         - `tooling` — build / CI / dev infra
       options:
+        - "none / unsure"
         - zkvm
         - compiler
         - downstream

--- a/.github/ISSUE_TEMPLATE/02-feature-request.yml
+++ b/.github/ISSUE_TEMPLATE/02-feature-request.yml
@@ -90,6 +90,7 @@ body:
         - `downstream` — proof generator / partner consumer
         - `tooling` — build / CI / dev infra
       options:
+        - "none / unsure"
         - zkvm
         - compiler
         - downstream

--- a/.github/ISSUE_TEMPLATE/03-documentation.yml
+++ b/.github/ISSUE_TEMPLATE/03-documentation.yml
@@ -36,6 +36,7 @@ body:
         - `downstream` — proof generator / partner consumer
         - `tooling` — build / CI / dev infra
       options:
+        - "none / unsure"
         - zkvm
         - compiler
         - downstream


### PR DESCRIPTION
## Description

A single-select issue-form dropdown defaults to its first option, so with `zkvm` listed first every web-UI submission that left Area untouched came through as `zkvm` — defeating the optional field and skewing the board. A leading `"none / unsure"` becomes the default no-area choice; `/workflow:create-issue` maps it to "no `area:*` label, infer instead". No `default:` is set, so the explicit none option is permitted.

Follow-up to #17, which merged before this fix landed (the fix was on a local amend that wasn't force-pushed in time).

## Related Issues/PRs

Follow-up to #17. Part of fractalyze/claude-plugins#39.

## Checklist

- [x] Branch name follows Branch Guideline
- [x] Commit messages follow Commit Message Guideline
- [x] Checked Pull Request Guideline