### PR TITLE
feat(issue-templates): use native Issue Type instead of type:* labels

### DIFF
--- a/.github/ISSUE_TEMPLATE/01-bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/01-bug-report.yml
@@ -1,7 +1,7 @@
 name: "Bug report"
 description: "Something broke. File a reproducer the next engineer can run."
 title: "fix: <one-line summary>"
-labels: ["type:fix"]
+type: Bug
 body:
   - type: checkboxes
     id: pre-check

--- a/.github/ISSUE_TEMPLATE/02-feature-request.yml
+++ b/.github/ISSUE_TEMPLATE/02-feature-request.yml
@@ -1,7 +1,7 @@
 name: "Feature request"
 description: "Propose new functionality. Alternatives + why are required — pick this template only after you've considered other paths."
 title: "feat: <one-line summary>"
-labels: ["type:feat"]
+type: Feature
 body:
   - type: checkboxes
     id: pre-check

--- a/.github/ISSUE_TEMPLATE/03-documentation.yml
+++ b/.github/ISSUE_TEMPLATE/03-documentation.yml
@@ -1,7 +1,7 @@
 name: "Documentation"
 description: "Something in the docs is wrong, missing, or unclear."
 title: "docs: <one-line summary>"
-labels: ["type:docs"]
+type: Task
 body:
   - type: input
     id: doc


### PR DESCRIPTION
## Description

Native Issue Types (`Task` / `Bug` / `Feature`) were enabled at the
fractalyze org level on 2025-11-11; these three universal templates
kept emitting `labels: ["type:*"]` as a stand-in, so issues filed via
the web UI carried the label but not the native field — and every
sampled `riscv-witness` issue had `type=null` even when it visibly
came from `02-feature-request.yml`. The YAML top-level `type:` key
sets the real field at file time, dropping the duplicate label axis.
The conventional-commit title prefix (`fix:` / `feat:` / `docs:`)
stays — it drives commits and release notes; the native Type is
orthogonal coarser classification for org-level reporting.

Universal templates are the org fallback — repos without their own
`.github/ISSUE_TEMPLATE/` overrides inherit these. The 7-repo per-repo
rollout already converted overriding templates (`riscv-witness#1347`
merged, six others in review); this PR closes the org-fallback gap.

## Related Issues/PRs

Pairs with `fractalyze/claude-plugins#41` (workflow skill switched to
reading the native field, also bundles the audit memo motivating this).
Companion PRs on the per-repo template rollout:
`whir-zorch#154`, `zk_dtypes#121`, `jax#158`, `prime-ir#326`,
`zkx#486`, `stablehlo#80` (all open, CI green).

## Checklist

- [x] Branch name follows Branch Guideline
- [x] Commit messages follow Commit Message Guideline
- [x] Checked Pull Request Guideline