### PR TITLE
fix: address the profile images absolutely so they load off github.com

### DIFF
--- a/profile/README.md
+++ b/profile/README.md
@@ -1,8 +1,8 @@
 <div align="left">
   <picture>
-    <source media="(prefers-color-scheme: dark)" srcset="./assets/fractalyze-logo-white.svg" />
-    <source media="(prefers-color-scheme: light)" srcset="./assets/fractalyze-logo-black.svg" />
-    <img alt="Fractalyze" src="./assets/fractalyze-logo-black.svg" height="80" />
+    <source media="(prefers-color-scheme: dark)" srcset="https://raw.githubusercontent.com/fractalyze/.github/main/profile/assets/fractalyze-logo-white.svg" />
+    <source media="(prefers-color-scheme: light)" srcset="https://raw.githubusercontent.com/fractalyze/.github/main/profile/assets/fractalyze-logo-black.svg" />
+    <img alt="Fractalyze" src="https://raw.githubusercontent.com/fractalyze/.github/main/profile/assets/fractalyze-logo-black.svg" height="80" />
   </picture>
 </div>
 
@@ -17,9 +17,9 @@ We build, optimize, and operate production cryptography systems, transforming tr
 A unified platform that automatically transforms high-level cryptographic applications into optimized execution for any target hardware.
 
 <picture>
-  <source media="(prefers-color-scheme: dark)" srcset="./assets/computing-layer-dark.png" />
-  <source media="(prefers-color-scheme: light)" srcset="./assets/computing-layer-light.png" />
-  <img alt="Today, an application reaches the hardware through five specialist teams, five rounds of handwork and a hardware-specific implementation. With Fractalyze, it reaches the same hardware through one orchestration and compiler layer." src="./assets/computing-layer-light.png" />
+  <source media="(prefers-color-scheme: dark)" srcset="https://raw.githubusercontent.com/fractalyze/.github/main/profile/assets/computing-layer-dark.png" />
+  <source media="(prefers-color-scheme: light)" srcset="https://raw.githubusercontent.com/fractalyze/.github/main/profile/assets/computing-layer-light.png" />
+  <img alt="Today, an application reaches the hardware through five specialist teams, five rounds of handwork and a hardware-specific implementation. With Fractalyze, it reaches the same hardware through one orchestration and compiler layer." src="https://raw.githubusercontent.com/fractalyze/.github/main/profile/assets/computing-layer-light.png" />
 </picture>
 
 Today, getting cryptography into production means protocol, compiler, GPU and runtime engineers working in separate silos, months of manual integration and tuning, and starting over for every new scheme or hardware target. We replace that with one compiler that optimizes and generates execution code, a runtime that handles execution and memory, and orchestration that scales the same workload across CPU, GPU, TPU and FPGA.
@@ -29,9 +29,9 @@ Today, getting cryptography into production means protocol, compiler, GPU and ru
 Build cryptographic applications in Python. Compile them into highly optimized execution for modern hardware.
 
 <picture>
-  <source media="(prefers-color-scheme: dark)" srcset="./assets/pipeline-dark.png" />
-  <source media="(prefers-color-scheme: light)" srcset="./assets/pipeline-light.png" />
-  <img alt="Pipeline: Zorch, FRX, StableHLO, XLA, PrimeIR, CPU and GPU." src="./assets/pipeline-light.png" />
+  <source media="(prefers-color-scheme: dark)" srcset="https://raw.githubusercontent.com/fractalyze/.github/main/profile/assets/pipeline-dark.png" />
+  <source media="(prefers-color-scheme: light)" srcset="https://raw.githubusercontent.com/fractalyze/.github/main/profile/assets/pipeline-light.png" />
+  <img alt="Pipeline: Zorch, FRX, StableHLO, XLA, PrimeIR, CPU and GPU." src="https://raw.githubusercontent.com/fractalyze/.github/main/profile/assets/pipeline-light.png" />
 </picture>
 
 **[Zorch]** — Build a SNARK in Python: define your IOP rounds and compose them. You write the protocol, and never touch the kernels. The blocks it gives you — hashing, Merkle commitment, Reed–Solomon LDE, transcript — hold no scheme-specific knowledge by rule, so a new prover adds only its own glue on top.
@@ -56,9 +56,9 @@ Provers and proving systems built on this stack:
 ## Benchmarks
 
 <picture>
-  <source media="(prefers-color-scheme: dark)" srcset="./assets/benchmark-dark.png" />
-  <source media="(prefers-color-scheme: light)" srcset="./assets/benchmark-light.png" />
-  <img alt="Eleven measured workloads plotted as our speed relative to the baseline, from 3.09x down to 0.94x, crossing parity between msm_bn254_g2 and sp1_logup_gkr." src="./assets/benchmark-light.png" />
+  <source media="(prefers-color-scheme: dark)" srcset="https://raw.githubusercontent.com/fractalyze/.github/main/profile/assets/benchmark-dark.png" />
+  <source media="(prefers-color-scheme: light)" srcset="https://raw.githubusercontent.com/fractalyze/.github/main/profile/assets/benchmark-light.png" />
+  <img alt="Eleven measured workloads plotted as our speed relative to the baseline, from 3.09x down to 0.94x, crossing parity between msm_bn254_g2 and sp1_logup_gkr." src="https://raw.githubusercontent.com/fractalyze/.github/main/profile/assets/benchmark-light.png" />
 </picture>
 
 Our speed as a multiple of the baseline's, measured against ICICLE, SP1 and Binius — parity at 1, including the two workloads where we are still behind.
@@ -77,14 +77,14 @@ Read the [blog] and the [docs], or see the whole picture at [fractalyze.io][Frac
 <div align="center">
   <a href="https://ethereum.foundation">
     <picture>
-      <source media="(prefers-color-scheme: dark)" srcset="./assets/ef-logo-light.svg" />
-      <source media="(prefers-color-scheme: light)" srcset="./assets/ef-logo-dark.svg" />
-      <img alt="Ethereum Foundation" src="./assets/ef-logo-dark.svg" height="44" align="middle" />
+      <source media="(prefers-color-scheme: dark)" srcset="https://raw.githubusercontent.com/fractalyze/.github/main/profile/assets/ef-logo-light.svg" />
+      <source media="(prefers-color-scheme: light)" srcset="https://raw.githubusercontent.com/fractalyze/.github/main/profile/assets/ef-logo-dark.svg" />
+      <img alt="Ethereum Foundation" src="https://raw.githubusercontent.com/fractalyze/.github/main/profile/assets/ef-logo-dark.svg" height="44" align="middle" />
     </picture>
   </a>
   &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
   <a href="https://www.nvidia.com/en-us/startups/">
-    <img alt="NVIDIA Inception Program" src="./assets/nvidia-inception-badge.png" height="57" align="middle" />
+    <img alt="NVIDIA Inception Program" src="https://raw.githubusercontent.com/fractalyze/.github/main/profile/assets/nvidia-inception-badge.png" height="57" align="middle" />
   </a>
 </div>
 


### PR DESCRIPTION
The diagrams have never rendered in the **GitHub mobile app**. Here's why.

GitHub rewrites a relative path in a profile README to a **root-relative** one:

```
./assets/pipeline-light.png
  ↓ as emitted on github.com/fractalyze
/fractalyze/.github/raw/main/profile/assets/pipeline-light.png
```

That resolves only when the base URL is `github.com`. Anywhere else it resolves against the wrong origin and 404s — verified: the same path against a non-GitHub base returns 404, while the absolute form returns 200.

Every image reference is now an absolute `raw.githubusercontent.com` URL (16 of them). The repo is public so they fetch anonymously, and raw serves the right content types — `image/png` for the PNGs, `image/svg+xml` for the SVGs — so both render inside an `<img>`.

### Tradeoff worth knowing

These URLs are **pinned to `main`**. A future PR that changes the artwork will show `main`'s images in its rich diff, not the branch's. Reviewing an artwork change now means opening the files in the PR rather than trusting the rendered page.

### Verification

All 11 distinct image URLs return 200 anonymously.

🤖 Generated with [Claude Code](https://claude.com/claude-code)