### PR TITLE
chore: disable Gemini Code Assist PR review

### DIFF
--- a/.gemini/config.yaml
+++ b/.gemini/config.yaml
@@ -1,0 +1,3 @@
+have_fun: false
+code_review:
+  disable: true


### PR DESCRIPTION
The gemini-code-assist GitHub App is installed org-wide (repository selection: all repos), so Gemini reviews every PR in this repo even when no `.gemini/` config exists — deleting the config alone would just revert it to default review behavior. `code_review.disable: true` is the documented per-repo off switch.

- `.gemini/config.yaml`: added, disabling all Gemini PR activity (the app was reviewing this repo with default settings)

Complete removal across the org additionally requires an org admin to uninstall the app at https://github.com/organizations/fractalyze/settings/installations — once that is done, the `.gemini/` files can be deleted entirely.