### PR TITLE
docs: replace the computing layer's opening line with the site's

### DIFF
--- a/profile/README.md
+++ b/profile/README.md
@@ -14,7 +14,7 @@ We build, optimize, and operate production systems, transforming trust-based dig
 
 ## The Computing Layer
 
-A unified platform that automatically transforms high-level cryptographic applications into optimized execution for any target hardware.
+We bring confidential and verifiable systems to production, from architecture and implementation to optimization and operations.
 
 <picture>
   <source media="(prefers-color-scheme: dark)" srcset="https://raw.githubusercontent.com/fractalyze/.github/main/profile/assets/computing-layer-dark.png" />


### PR DESCRIPTION
## What

One line, under `## The Computing Layer`.

```diff
-A unified platform that automatically transforms high-level cryptographic applications into optimized execution for any target hardware.
+We bring confidential and verifiable systems to production, from architecture and implementation to optimization and operations.
```

## Why

It is the framing the site led with before it was repositioned. "Cryptographic applications", "optimized execution", "any target hardware": that is the compiler's pitch, and it now agrees with neither the lead above it (the confidential and verifiable computing layer) nor the drawing under it, which since #26 runs requirements to a production system. The replacement is the site's own line from the same section, so the two say one thing.

## Why the heading stays

`The Computing Layer` is the positioning the profile already leads with, so it is not stale. It also does not have to match the site: `render-diagrams.py` finds each drawing by the heading of the section it sits in **on the website**, not by the heading here, which is what lets the profile carry its own headings and prose.

## Related

#25 carried the positioning over, #26 re-rendered the drawing. This is the last line those two left behind, flagged as a follow-up in #26.

🤖 Generated with [Claude Code](https://claude.com/claude-code)